### PR TITLE
1.1

### DIFF
--- a/ServerCoreTCP/Buffers/MRecvBuffer.cs
+++ b/ServerCoreTCP/Buffers/MRecvBuffer.cs
@@ -75,6 +75,11 @@ namespace ServerCoreTCP
             }
         }
 
+        public void ClearBuffer()
+        {
+            readPtr = writePtr = 0;
+        }
+
         /// <summary>
         /// Move the read pointer of the recvbuffer.
         /// </summary>

--- a/ServerCoreTCP/Buffers/RecvBuffer.cs
+++ b/ServerCoreTCP/Buffers/RecvBuffer.cs
@@ -77,6 +77,11 @@ namespace ServerCoreTCP
             }
         }
 
+        public void ClearBuffer()
+        {
+            readPtr = writePtr = 0;
+        }
+
         /// <summary>
         /// Move the read pointer of the recvbuffer.
         /// </summary>

--- a/ServerCoreTCP/LoggerDebug/CoreLogger.cs
+++ b/ServerCoreTCP/LoggerDebug/CoreLogger.cs
@@ -1,4 +1,6 @@
-﻿using Google.Protobuf;
+﻿#nullable enable
+
+using Google.Protobuf;
 using Serilog;
 using Serilog.Core;
 using System;
@@ -29,14 +31,14 @@ namespace ServerCoreTCP.CLogger
             if ((flag & (uint)LoggerSinks.DEBUG) == (uint)LoggerSinks.DEBUG)
             {
                 config.WriteTo.Debug(
-                    outputTemplate: loggerConfig.OutputTemplate, 
+                    outputTemplate: loggerConfig.OutputTemplate,
                     restrictedToMinimumLevel: loggerConfig.RestrictedMinimumLevel);
             }
 
             if ((flag & (uint)LoggerSinks.CONSOLE) == (uint)LoggerSinks.CONSOLE)
             {
                 config.WriteTo.Console(
-                    outputTemplate: loggerConfig.OutputTemplate, 
+                    outputTemplate: loggerConfig.OutputTemplate,
                     restrictedToMinimumLevel: loggerConfig.RestrictedMinimumLevel);
             }
 
@@ -50,18 +52,18 @@ namespace ServerCoreTCP.CLogger
                     flushToDiskInterval: loggerConfig.FlushToDistInterval);
             }
 
-            CLogger =  config.CreateLogger();
+            CLogger = config.CreateLogger();
         }
 
         public static void StopLogging()
         {
-            CLogger.Dispose();
+            CLogger?.Dispose();
         }
 
         public static void LogInfo(string header, string messageTemplate, params object?[]? propertyValues)
         {
             string msg = $"[{header}] {messageTemplate}";
-            CLogger.Information(msg, propertyValues);
+            CLogger?.Information(msg, propertyValues);
         }
 
         public static void LogError(string header, Exception ex, string messageTemplate, params object?[]? propertyValues)

--- a/ServerCoreTCP/Network/Service.cs
+++ b/ServerCoreTCP/Network/Service.cs
@@ -15,6 +15,9 @@ namespace ServerCoreTCP
         public ServiceTypes ServiceType => m_serviceType;
         readonly internal ServiceTypes m_serviceType;
 
+        public int SAEATotalPoolCount => m_saeaPool.TotalPoolCount;
+        public int SAEACurrentPooledCount => m_saeaPool.CurrentPooledCount;
+
         internal readonly SocketAsyncEventArgsPool m_saeaPool;
 
         public abstract void Start();
@@ -44,14 +47,8 @@ namespace ServerCoreTCP
     {
         readonly int m_sessionPoolCount;
 
-        public int PooledSessionCount
-        {
-            get
-            {
-                if (m_sessionPool == null) return -1;
-                else return m_sessionPool.PooledSessionCount;
-            }
-        }
+        public int SessionTotalPoolCount => m_sessionPool.TotalPoolCount;
+        public int SessionCurrentPooledCount => m_sessionPool.CurrentPooledCount;
 
         readonly Listener m_listener;
         internal SessionPool m_sessionPool;

--- a/ServerCoreTCP/Network/SessionPool.cs
+++ b/ServerCoreTCP/Network/SessionPool.cs
@@ -3,28 +3,34 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ServerCoreTCP
 {
     internal class SessionPool
     {
-        internal int PooledSessionCount => m_pool.Count;
+        public int TotalPoolCount => m_id - 1;
+        public int CurrentPooledCount => m_pool.Count;
 
         readonly ConcurrentStack<Session> m_pool;
         readonly Func<Session> m_emptySessionFactory;
+        readonly Service m_service;
+
+        int m_id = 1; // starts at 1
 
         internal SessionPool(Service service, int capacity, Func<Session> emptySessionFactory)
         {
+            m_service = service;
             m_pool = new ConcurrentStack<Session>();
 
             m_emptySessionFactory = emptySessionFactory;
 
-            for (uint i = 0; i < capacity; ++i)
+            for (m_id = 1; m_id <= capacity; ++m_id)
             {
                 Session session = m_emptySessionFactory.Invoke();
-                session.SetService(service);
-                session.SetSessionId(i + 1);
+                session.SetService(m_service);
+                session.SetSessionId((uint)m_id);
                 m_pool.Push(session);
             }
         }
@@ -32,7 +38,7 @@ namespace ServerCoreTCP
         internal Session Pop()
         {
             if (m_pool.TryPop(out var session) == true) return session;
-            else return null;
+            else return CreateNew();
         }
 
         internal void Push(Session session)
@@ -48,6 +54,17 @@ namespace ServerCoreTCP
         internal void Clear()
         {
             m_pool.Clear();
+        }
+
+        Session CreateNew()
+        {
+            int id = Interlocked.Increment(ref m_id);
+
+            Session session = m_emptySessionFactory.Invoke();
+            session.SetService(m_service);
+            session.SetSessionId((uint)m_id);
+
+            return session;
         }
     }
 }

--- a/ServerCoreTCP/Network/SocketAsyncEventArgsPool.cs
+++ b/ServerCoreTCP/Network/SocketAsyncEventArgsPool.cs
@@ -1,30 +1,41 @@
 ﻿using System;
 using System.Net.Sockets;
 using System.Collections.Concurrent;
+using System.Threading;
 
 namespace ServerCoreTCP
 {
     internal class SocketAsyncEventArgsPool
     {
+        public int TotalPoolCount => m_totalCount;
+        public int CurrentPooledCount => m_pool.Count;
+
+
         readonly ConcurrentStack<SocketAsyncEventArgs> m_pool;
+        readonly Action<object, SocketAsyncEventArgs> m_completedCallback;
+
+        int m_totalCount = 0;
 
         internal SocketAsyncEventArgsPool(int capacity, Action<object, SocketAsyncEventArgs> completedCallback)
         {
+            m_completedCallback = completedCallback;
             m_pool = new ConcurrentStack<SocketAsyncEventArgs>();
 
             for (int i = 0; i < capacity; ++i)
             {
-                var e = new SocketAsyncEventArgs();
-                e.Completed += new EventHandler<SocketAsyncEventArgs>(completedCallback);
-                m_pool.Push(e);
+                var args = CreateNew();
+                m_pool.Push(args);
+
+                //var e = new SocketAsyncEventArgs();
+                //e.Completed += new EventHandler<SocketAsyncEventArgs>(m_completedCallback);
+                //m_pool.Push(e);
             }
         }
 
         internal SocketAsyncEventArgs Pop()
         {
             if (m_pool.TryPop(out var args) == true) return args;
-            //else return CreateNewArgs();
-            else return null;
+            else return CreateNew();
         }
 
         internal void Push(SocketAsyncEventArgs args)
@@ -43,6 +54,16 @@ namespace ServerCoreTCP
         internal void Clear()
         {
             m_pool.Clear();
+        }
+
+        SocketAsyncEventArgs CreateNew()
+        {
+            _ = Interlocked.Increment(ref m_totalCount);
+
+            var args = new SocketAsyncEventArgs();
+            args.Completed += new EventHandler<SocketAsyncEventArgs>(m_completedCallback);
+
+            return args;
         }
     }
 }

--- a/ServerCoreTCP/ServerCoreTCP.csproj
+++ b/ServerCoreTCP/ServerCoreTCP.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;MESSAGE_WRAPPER_PACKET</DefineConstants>
+    <DefineConstants>TRACE;MESSAGE_WRAPPER_PACKET;</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/ServerCoreTCP/Utils/Extends.cs
+++ b/ServerCoreTCP/Utils/Extends.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net.Sockets;
-using System.Text;
+﻿using System.Net.Sockets;
 
 namespace ServerCoreTCP.Utils
 {
@@ -25,11 +22,6 @@ namespace ServerCoreTCP.Utils
         public static void SetReuseAddress(this Socket socket, bool reuseAddress)
         {
             SocketUtils.SetReuseAddress(socket, reuseAddress);
-        }
-
-        public static void SetKeepAlive(this Socket socket, int keepAliveTime, int keepAliveInterval)
-        {
-            SocketUtils.SetKeepAlive(socket, keepAliveTime, keepAliveInterval);
         }
     }
 }

--- a/ServerCoreTCP/Utils/SocketUtils.cs
+++ b/ServerCoreTCP/Utils/SocketUtils.cs
@@ -28,26 +28,5 @@ namespace ServerCoreTCP.Utils
         {
             socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, reuseAddress);
         }
-
-        // low-level api
-        public static void SetKeepAlive(Socket socket, int keepAliveTime, int keepAliveInterval)
-        {
-            try
-            {
-                // set keepalive true on socket level
-                socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
-
-                // set keepalive true on tcp level
-                socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.KeepAlive, BitConverter.GetBytes(1));
-
-                byte[] keepAliveTimeValues = BitConverter.GetBytes(keepAliveTime);
-                byte[] keepAliveIntervalValues = BitConverter.GetBytes(keepAliveInterval);
-                socket.IOControl(IOControlCode.KeepAliveValues, keepAliveTimeValues, keepAliveIntervalValues);
-            }
-            catch(Exception ex)
-            {
-                CoreLogger.LogError("SocketUtils.SetKeepAlive", ex, "Exception");
-            }
-        }
     }
 }

--- a/TCPServer.sln
+++ b/TCPServer.sln
@@ -18,7 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PacketFactories", "PacketFa
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessageWrapperFactory", "MessageWrapperFactory\MessageWrapperFactory.csproj", "{661F6258-74E0-436F-BC7D-8F2791C28311}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MessageFactory", "MessageFactory\MessageFactory.csproj", "{EFA09BCB-6D3E-4294-91C3-0EC1523D3D0F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessageFactory", "MessageFactory\MessageFactory.csproj", "{EFA09BCB-6D3E-4294-91C3-0EC1523D3D0F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/TCPServer/Program.cs
+++ b/TCPServer/Program.cs
@@ -46,7 +46,11 @@ namespace ChatServer
                         else Console.WriteLine("Not started");
                         break;
                     case "pooled_session_count":
-                        if (Server.IsOn == true) Console.WriteLine($"{Server.Instance._networkManager?.serverService?.PooledSessionCount}");
+                        if (Server.IsOn == true) Console.WriteLine($"{Server.Instance._networkManager?.serverService?.SessionCurrentPooledCount}");
+                        else Console.WriteLine("Not started");
+                        break;
+                    case "pooled_saea_count":
+                        if (Server.IsOn == true) Console.WriteLine($"{Server.Instance._networkManager?.serverService?.SAEACurrentPooledCount}");
                         else Console.WriteLine("Not started");
                         break;
                     case "collect":


### PR DESCRIPTION
1. Removed SetSocketOption method using IOControl about KeepAlive.
2. When the session is expired, the pointers(write, read) of recvBuffer are set to 0 now.
3. The current count and total count of pooled count in SAEAPool and Session Pool are accessable through Service now.
4. Added `#nullable enable` at CLogger.
5. In the pool(SAEA, Session), when the TryPop is failed, the pool return new object instead of null and the count will be increased.